### PR TITLE
add: Workflow to run and upload code coverage

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -1,0 +1,29 @@
+ name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Setup Python  
+      uses: actions/setup-python@master
+      with:
+        python-version: 3.7
+    - name: Generate coverage report
+      run: |
+        pip install pytest
+        pip install pytest-cov
+        pytest --cov=./ --cov-report=xml
+    - name: Upload coverage to Codecov  
+      uses: codecov/codecov-action@v1.0.5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-umbrella
+        yml: ./codecov.yml 
+        fail_ci_if_error: true

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -1,4 +1,4 @@
- name: CI
+name: CI
 
 on: [push]
 


### PR DESCRIPTION
In order to run some test coverage of the repository code, we can leverage the Github Actions Workflow:
1. Create a Workflow with a `ubuntu:latest` image.
2. Install `python 3.7` environment in the image.
3. Install `pytest` and `pytest-cov` (which depends on `coverage`.
    Run `pytest` and create a coverage report.
4. Upload the `coverage.xml` report to `codecov.io` using my API key (stored in Github secrets).